### PR TITLE
constant-time CtSelOps 봉인으로 swap 소거 UB 위험 제거

### DIFF
--- a/constant-time/README.md
+++ b/constant-time/README.md
@@ -1,0 +1,49 @@
+# 상수-시간 (Constant-Time, CT) 모듈
+
+[![Language](https://img.shields.io/badge/README-English_Ver-blue?style=for-the-badge)](README_EN.md)
+
+암호화에는 상수-시간 로직이 매우 중요합니다. 이 문서는 이 프로젝트에서 상수-시간이 어떻게 동작하는지에 대해 기술적으로 설명합니다.
+
+---
+
+## 발견한 문제와 조치
+
+구현된 상수-시간 로직에 존재하는 문제와 해결을 기술합니다.
+
+### Fallback 경로의 `black_box` 의존 문제 (예정)
+
+`black_box`는 Rust 공식적으로 ["최적화 배리어를 보장하지 않는다"](https://internals.rust-lang.org/t/optimization-barriers-suitable-for-cryptographic-use/21047)고 못박혀 있습니다. 컴파일러는 `black_box`를 통째로 무시할 자유가 있습니다만, `ct_sel64`, `ct_eq64`, `ct_mask`([internal.rs](src/internal.rs))가 아무리 `(m & a) | (!m & b)` 같은 분기 없이 작성되어 있어도 최적화기가 이 패턴을 `select` 관용구로 재인식해서 `cmov`나 최악의 경우 분기로 되돌릴 가능성을 언어 차원에서 막을 방법이 없습니다. 즉, "태생적 불확실성"이라 볼 수 있습니다. 이건 `black_box`의 설계 자체에서 오는 거라 코드를 더 잘 작성해도 해소가 안 됩니다.
+
+하지만 다행히도, 산술 자체는 mul/div/branch 같은 고전적 가변-시간 명령을 사용하지 않고 AND/OR/shift/sub만 사용하여 잔여 리스크는 사실상 "최적화기가 분기를 재구성하는 경우" 하나로 좁혀져 있습니다.
+
+`#[deprecated]` const 트릭, 각 함수 `# Security Note`까지 보면 알 수 있듯 코드의 '약함'은 저 또한 명확히 인지하고 있습니다. 문제는 이게 경고 수준이라는 것입니다. 따라서 제가 이 시점에 생각한 대안은 "인-라인 어셈블리 미지원 타겟은 `compiler_fence` fallback 또는 `Err(Unsupported)` 명시 반환"이며, 지원 타겟을 AMD64 + AArch64 둘로 결정하는 것입니다. **추 후 PR을 통해 이러한 문제를 '게이트'로 명명짓고 강화를 수행하겠습니다.**
+
+---
+
+### swap 메모리 소거의 UB(Undefined Behavior) 위험 문제 (해결)
+
+이 문제는 심각성이 높았습니다. `CtSelOps`는 `pub` 트레이트고, 바운드가 `: Copy` 하나뿐이었습니다. `Copy` 바운드가 막아주는 건 `Drop` 타입뿐이고(Copy와 Drop은 공존 불가), 니치(niche)를 가진 `Copy` 타입은 막지 못 합니다. 그래서 다음과 같이 확장한다면,
+
+```rust
+impl CtSelOps for SomeCopyTypeWithNiche { ... }
+```
+
+여기서 `SomeCopyTypeWithNiche가 &'static T`, `NonZeroU32`, `fn()`, `NonNull<T>`, 또는 이들을 필드로 가진 구조체라면, all-zero를 써넣는 순간 invalid value(null 참조, 0인 NonZero, null 함수 포인터)가 만들어지게 됩니다. Rust에서 **타입이 붙은 place가 invalid value를 보유하는 것 자체가 UB**입니다. "어차피 안 읽으니 괜찮다"는 엄격한 유효성 검사(strict validity) 기준에서 통하지 않습니다. `Copy` 바운드 덕분에 `Drop` 기반 변종은 이미 막혀 있었고 이는 레일이 하나는 있는 셈인데, 그것만으론 니치를 막을 순 없었습니다.
+
+추가로, [커밋](https://github.com/Quant-Off/elib-k0-nt/tree/db229a365efdd4327b74b7c01c563820b566ae57)에서 `swap`의 [Safety docstring](https://github.com/Quant-Off/elib-k0-nt/blob/db229a365efdd4327b74b7c01c563820b566ae57/constant-time/src/lib.rs#L170-L182)은 `Self: Copy + Sized`만 근거로 건전성을 주장하는데, "all-zero가 Self의 유효한 값이어야 한다"는 전제를 명시하지 않아 살짝 과대 주장 상태이기도 했습니다.
+
+#### 해결
+
+이 문제는 [PR #6](https://github.com/Quant-Off/elib-k0-nt/pull/6)에서 (A) 트레이트 봉인(seal) 방식으로 해결했습니다.
+
+`private` 모듈의 `Sealed` 마커 트레이트를 `CtSelOps`의 슈퍼트레이트로 지정하고, `Sealed`를 크레이트 내부의 고정폭 정수(`u8..i128`)에만 구현했습니다.
+
+```rust
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait CtSelOps: Copy + private::Sealed { /* ... */ }
+```
+
+이제 외부 크레이트는 자기 타입에 `CtSelOps`를 구현할 수 없으므로, `swap`이 소거하는 `Self`는 all-zero가 항상 유효한 고정폭 정수로 한정됩니다. 니치(niche) 타입이 끼어들 길이 사라져 invalid value UB가 구조적으로 불가능해지며, 소거 핫패스 코드는 한 줄도 바뀌지 않습니다. 더불어 `swap`의 `# Safety` 문서에 이 봉인 불변식을 명시하여 기존의 과대 주장도 함께 바로잡았습니다.

--- a/constant-time/src/lib.rs
+++ b/constant-time/src/lib.rs
@@ -141,7 +141,7 @@ impl Not for Choice {
 /// 조건에 따라 두 값 중 하나를 상수-시간에 선택하는 연산을 정의하는 트레이트입니다.
 ///
 /// `assign`과 `swap`은 `select`에서 파생됩니다.
-pub trait CtSelOps: Copy {
+pub trait CtSelOps: Copy + private::Sealed {
     /// `choice`가 1이면 `b`를, 0이면 `a`를 상수-시간에 선택하여 반환하는 함수입니다.
     ///
     /// # Arguments
@@ -171,7 +171,9 @@ pub trait CtSelOps: Copy {
     /// 임시 변수 `t`는 `Self: Copy + Sized`이며 함수 로컬 스택 슬롯에만
     /// 존재합니다. 각 바이트의 volatile write는 별칭 없는 유일 포인터로
     /// 수행되므로 경합이 없고 `write_volatile`는 죽은 코드 제거 대상이
-    /// 아닙니다.
+    /// 아닙니다. 또한 `CtSelOps`는 `private::Sealed`로 봉인되어 구현자가
+    /// 고정폭 정수로 제한되므로 all-zero 비트 패턴이 항상 `Self`의 유효한
+    /// 값이며 volatile 0 덮어쓰기가 invalid value를 만들지 않습니다.
     ///
     /// # Security Note
     /// 임시 변수 `t`는 `*a`의 평문 사본을 일시적으로 보유합니다. 함수 종료 시
@@ -245,6 +247,22 @@ impl CtSelOps for i128 {
         u128::select(&(*a as u128), &(*b as u128), choice) as i128
     }
 }
+
+mod private {
+    pub trait Sealed {}
+}
+
+macro_rules! impl_sealed {
+    ($($t:ty),+) => {
+        $(
+            impl private::Sealed for $t {}
+        )+
+    };
+}
+
+impl_sealed!(
+    u8, u16, u32, i8, i16, i32, u64, i64, usize, isize, u128, i128
+);
 
 //
 // CtEqOps 트레이트 (eq, ne)


### PR DESCRIPTION
## 배경

`CtSelOps::swap`은 기본 트레이트 메서드로, 임시값 `t: Self`를 `size_of::<Self>()` 바이트 전체에 raw `write_volatile(.., 0)`으로 소거한다. 트레이트 바운드가 `: Copy` 하나뿐이라 `Copy`이면서 니치(niche)를 가진 타입(`&T`, `NonZeroU32`, `fn()`, `NonNull<T>` 등)을 외부에서 구현하면, all-zero 소거가 invalid value를 만들어 UB가 발생할 수 있었다. `Copy` 바운드는 `Drop` 변종만 막아줄 뿐 니치는 막지 못한다.

현재 구현자는 고정폭 정수뿐이라 실제 UB는 없지만, 타입 확장 시 터지는 잠재적 건전성 지뢰다.

## 조치 (A 트레이트 봉인)

- `private::Sealed` 마커 트레이트를 `CtSelOps`의 슈퍼트레이트로 지정
- `Sealed`는 크레이트 내부 고정폭 정수(`u8..i128`)에만 구현
- 외부 크레이트가 임의 타입에 `CtSelOps`를 구현할 수 없게 되어, `swap`이 다루는 `Self`는 항상 all-zero가 유효한 정수로 한정 -> UB 구조적으로 소멸
- 소거 핫패스 코드는 변경 없음
- `swap`의 `# Safety` 문서에 봉인 불변식 명시(기존 과대 주장 교정)

기존 사용처(ECC limb 등)는 전부 `u64::swap` 같은 정수 단위 호출이라 영향 없음.

## 검증

- `cargo fmt` clean
- `cargo clippy --all-targets --all-features --target aarch64-apple-darwin -- -D warnings` 무경고
- lib 단위 테스트 6/6 통과(`ct_sel_swap_value_roundtrip` 포함)